### PR TITLE
Support JSON marshalling and unmarshalling for the `Route` struct value

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -2,6 +2,7 @@ package iprtb
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 )
@@ -401,4 +402,44 @@ func ExampleRouteTable_ClearRoutes() {
 	// 192.0.2.255/32	192.0.2.255	ifb0	1
 	// false
 	// false
+}
+
+func ExampleRoute_MarshalJSON() {
+	r := &Route{
+		Destination: &net.IPNet{
+			IP:   net.IPv4(192, 0, 2, 0).To4(),
+			Mask: net.IPv4Mask(255, 255, 255, 0),
+		},
+		Gateway:          net.IPv4(192, 0, 2, 1),
+		NetworkInterface: "ifb0",
+		Metric:           1,
+	}
+
+	marshalled, err := json.Marshal(r)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%s\n", marshalled)
+
+	// Output:
+	// {"destination":"192.0.2.0/24","gateway":"192.0.2.1","networkInterface":"ifb0","metric":1}
+}
+
+func ExampleRoute_UnmarshalJSON() {
+	var r Route
+	err := json.Unmarshal([]byte(`{"destination":"192.0.2.0/24","gateway":"192.0.2.1","networkInterface":"ifb0","metric":1}`), &r)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("destination: %s\n", r.Destination.String())
+	fmt.Printf("gateway: %s\n", r.Gateway.String())
+	fmt.Printf("networkInterface: %s\n", r.NetworkInterface)
+	fmt.Printf("metric: %d\n", r.Metric)
+
+	// Output:
+	// destination: 192.0.2.0/24
+	// gateway: 192.0.2.1
+	// networkInterface: ifb0
+	// metric: 1
 }

--- a/routes.go
+++ b/routes.go
@@ -1,6 +1,7 @@
 package iprtb
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 )
@@ -17,6 +18,8 @@ func (rs Routes) String() string {
 }
 
 // Route is an entry of routing table.
+//
+// This struct type supports JSON marshalling and unmarshalling. Please refer also to RouteJSON for more information about that.
 type Route struct {
 	Destination      *net.IPNet
 	Gateway          net.IP
@@ -26,4 +29,45 @@ type Route struct {
 
 func (r Route) String() string {
 	return fmt.Sprintf("%s\t%s\t%s\t%d", r.Destination.String(), r.Gateway.String(), r.NetworkInterface, r.Metric)
+}
+
+// RouteJSON is an intermediate representation for Route to do JSON marshalling and unmarshalling.
+//
+// When it marshals Route to JSON bytes, it transforms a Route value to a RouteJSON and applies that to `json.Marshal()`.
+// Also, hen it attempts to unmarshal JSON bytes to a Route value, it applies `json.Unmarshal()` to that JSON bytes to
+// derive the RouteJSON value at first, and after that, it converts that RouteJSON value into a Route value.
+type RouteJSON struct {
+	Destination      string `json:"destination"`
+	Gateway          string `json:"gateway"`
+	NetworkInterface string `json:"networkInterface"`
+	Metric           int    `json:"metric"`
+}
+
+func (r Route) MarshalJSON() ([]byte, error) {
+	rj := &RouteJSON{
+		Destination:      r.Destination.String(),
+		Gateway:          r.Gateway.String(),
+		NetworkInterface: r.NetworkInterface,
+		Metric:           r.Metric,
+	}
+	return json.Marshal(rj)
+}
+
+func (r *Route) UnmarshalJSON(data []byte) error {
+	var rj RouteJSON
+	err := json.Unmarshal(data, &rj)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal Route: %w", err)
+	}
+
+	_, destination, err := net.ParseCIDR(rj.Destination)
+	if err != nil {
+		return fmt.Errorf(`failed to unmarshal Route; it cannot parse the value of "destination" property as net.IPNet: %w`, err)
+	}
+
+	r.Destination = destination
+	r.Gateway = net.ParseIP(rj.Gateway)
+	r.NetworkInterface = rj.NetworkInterface
+	r.Metric = rj.Metric
+	return nil
 }

--- a/routes_test.go
+++ b/routes_test.go
@@ -1,0 +1,41 @@
+package iprtb
+
+import (
+	"encoding/json"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoute_MarshalJSON(t *testing.T) {
+	r := &Route{
+		Destination: &net.IPNet{
+			IP:   net.IPv4(192, 0, 2, 0).To4(),
+			Mask: net.IPv4Mask(255, 255, 255, 0),
+		},
+		Gateway:          net.IPv4(192, 0, 2, 1),
+		NetworkInterface: "ifb0",
+		Metric:           1,
+	}
+
+	marshalled, err := json.Marshal(r)
+	assert.NoError(t, err)
+
+	var unmarshalled Route
+	err = json.Unmarshal(marshalled, &unmarshalled)
+	assert.NoError(t, err)
+	assert.EqualValues(t, r, &unmarshalled)
+}
+
+func TestRoute_UnmarshalJSON_FailToUnmarshalRouteJson(t *testing.T) {
+	var r Route
+	err := json.Unmarshal([]byte(`{"metric":"__invalid-NaN__"}`), &r)
+	assert.Error(t, err)
+	assert.True(t, strings.HasPrefix(err.Error(), "failed to unmarshal Route:"))
+
+	err = json.Unmarshal([]byte(`{"destination":"192.0.2.0/INVALID"}`), &r)
+	assert.Error(t, err)
+	assert.True(t, strings.HasPrefix(err.Error(), `failed to unmarshal Route; it cannot parse the value of "destination" property as net.IPNet:`))
+}


### PR DESCRIPTION
## Examples

### Marshalling

```go
func ExampleRoute_MarshalJSON() {
	r := &Route{
		Destination: &net.IPNet{
			IP:   net.IPv4(192, 0, 2, 0).To4(),
			Mask: net.IPv4Mask(255, 255, 255, 0),
		},
		Gateway:          net.IPv4(192, 0, 2, 1),
		NetworkInterface: "ifb0",
		Metric:           1,
	}

	marshalled, err := json.Marshal(r)
	if err != nil {
		panic(err)
	}
	fmt.Printf("%s\n", marshalled)

	// Output:
	// {"destination":"192.0.2.0/24","gateway":"192.0.2.1","networkInterface":"ifb0","metric":1}
}
```

### Unmarshalling

```go
func ExampleRoute_UnmarshalJSON() {
	var r Route
	err := json.Unmarshal([]byte(`{"destination":"192.0.2.0/24","gateway":"192.0.2.1","networkInterface":"ifb0","metric":1}`), &r)
	if err != nil {
		panic(err)
	}

	fmt.Printf("destination: %s\n", r.Destination.String())
	fmt.Printf("gateway: %s\n", r.Gateway.String())
	fmt.Printf("networkInterface: %s\n", r.NetworkInterface)
	fmt.Printf("metric: %d\n", r.Metric)

	// Output:
	// destination: 192.0.2.0/24
	// gateway: 192.0.2.1
	// networkInterface: ifb0
	// metric: 1
}
```